### PR TITLE
miseをshimsモードに変更（p10k描画競合の修正）

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -40,6 +40,9 @@ eval "$(/opt/homebrew/bin/brew shellenv)"
 # Antigravity
 export PATH="$HOME/.antigravity/antigravity/bin:$PATH"
 
+# Claude Code
+export PATH="$HOME/.local/bin:$PATH"
+
 # mise (asdf successor, shims mode to avoid p10k precmd conflict)
 if command -v mise &>/dev/null; then
   eval "$(mise activate zsh --shims)"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -40,9 +40,9 @@ eval "$(/opt/homebrew/bin/brew shellenv)"
 # Antigravity
 export PATH="$HOME/.antigravity/antigravity/bin:$PATH"
 
-# mise (asdf successor)
+# mise (asdf successor, shims mode to avoid p10k precmd conflict)
 if command -v mise &>/dev/null; then
-  eval "$(mise activate zsh)"
+  eval "$(mise activate zsh --shims)"
 fi
 
 # fzf


### PR DESCRIPTION
## Summary
- `mise activate zsh` → `mise activate zsh --shims` に変更
- miseの`precmd`フックがp10kのプロンプト描画と競合し、入力文字が消える問題を修正

## 原因
`mise activate zsh`は毎回のプロンプト表示前に`precmd`フックで環境変数を更新する。これがp10kの描画処理と競合してターミナルの表示がずれていた。

## 修正
`--shims`モードはフックを使わず、PATHにshimsディレクトリを追加するだけなのでp10kと干渉しない。

## Test plan
- [ ] ターミナルで入力文字が正常に表示される
- [ ] `mise list` でランタイムが表示される
- [ ] CI が通ることを確認