### PR TITLE
グローバルgitignoreを有効化しセキュリティパターンを追加

### DIFF
--- a/git/config
+++ b/git/config
@@ -1,3 +1,5 @@
+[core]
+	excludesfile = ~/.gitignore_global
 [user]
 	name = tomitamasa
 	email = 41310325+tomitamasa@users.noreply.github.com

--- a/git/ignore
+++ b/git/ignore
@@ -1,2 +1,18 @@
+# OS
 .DS_Store
 dist
+
+# Security - secrets and credentials
+.secrets
+.env
+.env.local
+.env.production
+.env.staging
+*.pem
+*.p12
+*.pfx
+*.key
+*_rsa
+*_dsa
+*_ecdsa
+*_ed25519


### PR DESCRIPTION
## Summary
- `git/config`に`core.excludesfile`が未設定で、`git/ignore`（`~/.gitignore_global`）が全リポジトリに適用されていなかった
- これにより`.env`や`.secrets`が他リポジトリで誤って`git add`できる状態だった
- `git/ignore`にセキュリティパターン（`.secrets`, `.env*`, 秘密鍵等）を追加

## Test plan
- [ ] `git config --global core.excludesfile` で `~/.gitignore_global` が返ること
- [ ] 新規リポジトリで `.env`, `.secrets`, `*.pem` が `git status` に表示されないこと