### PR TITLE
CIの改善と.gitignoreからFish残骸を削除

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,10 +14,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install dependencies
+        run: brew install shellcheck sheldon fzf mise ghq
+
       - name: Shellcheck
-        run: |
-          brew install shellcheck
-          find scripts -name "*.sh" -exec shellcheck -x {} \;
+        run: find scripts -name "*.sh" -exec shellcheck -x {} \;
 
       - name: Verify symlink creation
         run: |
@@ -32,9 +33,28 @@ jobs:
           readlink ~/.config/sheldon/plugins.toml | grep -q "zsh/plugins.toml"
           echo "All symlinks OK"
 
+      - name: Verify global gitignore
+        run: |
+          # core.excludesfile must be set
+          git config --global core.excludesfile | grep -q "gitignore_global" \
+            || { echo "FAIL: core.excludesfile not set"; exit 1; }
+          echo "OK: core.excludesfile -> $(git config --global core.excludesfile)"
+
+          # Sensitive files must be ignored in any repo
+          cd "$(mktemp -d)"
+          git init -q
+          touch .env .secrets test.pem normal.txt
+          untracked=$(git status --porcelain)
+          echo "$untracked" | grep -q "normal.txt" \
+            || { echo "FAIL: normal.txt should be untracked"; exit 1; }
+          for f in .env .secrets test.pem; do
+            echo "$untracked" | grep -q "$f" \
+              && { echo "FAIL: $f should be globally ignored"; exit 1; }
+          done
+          echo "Global gitignore OK"
+
       - name: Verify Sheldon plugins
         run: |
-          brew install sheldon
           sheldon lock --update
           echo "Sheldon plugins OK"
 
@@ -53,7 +73,6 @@ jobs:
 
       - name: Verify .zshrc loads and tool paths
         run: |
-          brew install fzf mise ghq
           DOTFILES_ZSH="$(pwd)/zsh" zsh -c '
             source '"$(pwd)"'/zsh/.zshrc
 

--- a/.gitignore
+++ b/.gitignore
@@ -34,19 +34,6 @@ Thumbs.db
 *.swo
 *~
 
-# Fish plugin files (managed by fisher)
-# Plugins install to ~/.config/fish/ (symlinked), but we only track our custom files
-fish/functions/_*
-fish/functions/fzf_configure_bindings.fish
-fish/functions/fish_mode_prompt.fish
-fish/functions/fish_prompt.fish
-fish/functions/tide*
-fish/completions/fzf_configure_bindings.fish
-fish/completions/tide.fish
-fish/conf.d/_*
-fish/conf.d/autopair.fish
-fish/conf.d/fzf.fish
-
 # Backup files created by install.sh
 *.backup
 **/*.backup


### PR DESCRIPTION
## Summary
- `brew install`を1ステップに集約（各ステップでの個別インストールを廃止）
- グローバルgitignoreの検証ステップを追加（`core.excludesfile`設定と`.env`/`.secrets`のignore動作を検証）
- `.gitignore`からFish shell関連パターンを削除（PR #20でZsh移行済み）

## Test plan
- [ ] CIが通ること（特に新しい「Verify global gitignore」ステップ）