### PR TITLE
.gitignoreにdata/を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 # Personal/Local files
 .local/
 .cache/
+data/
 temp/
 tmp/
 


### PR DESCRIPTION
## Summary
- redash-mcpのキャッシュDB（`data/cache.db`等）がuntracked filesとして表示されていたため、`.gitignore`に`data/`を追加

## Test plan
- [ ] `git status` でdata/が表示されないことを確認