### PR TITLE
macOS defaults自動設定スクリプトを追加

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,11 @@ jobs:
           done
           echo "Global gitignore OK"
 
+      - name: Verify macOS defaults script
+        run: |
+          source scripts/lib/macos.sh
+          type configure_macos
+
       - name: Verify Sheldon plugins
         run: |
           sheldon lock --update

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,6 +25,7 @@ echo "✅ macOS detected"
 source "$SCRIPT_DIR/lib/brew.sh"
 source "$SCRIPT_DIR/lib/symlinks.sh"
 source "$SCRIPT_DIR/lib/zsh.sh"
+source "$SCRIPT_DIR/lib/macos.sh"
 
 # Create necessary directories
 echo "📁 Creating necessary directories..."
@@ -45,6 +46,9 @@ install_additional_fonts
 
 # Install Zsh plugins
 install_zsh_plugins
+
+# Configure macOS system preferences
+configure_macos
 
 echo ""
 echo "🎉 Dotfiles installation completed successfully!"

--- a/scripts/lib/macos.sh
+++ b/scripts/lib/macos.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# macOS system preferences configuration
+# Used by install.sh for configuring macOS defaults
+
+configure_macos() {
+  echo "🍎 Configuring macOS system preferences..."
+
+  # --- Dock ---
+  defaults write com.apple.dock autohide -bool true
+  defaults write com.apple.dock tilesize -int 26
+  defaults write com.apple.dock orientation -string "right"
+  defaults write com.apple.dock magnification -bool true
+
+  # --- Finder ---
+  defaults write NSGlobalDomain AppleShowAllExtensions -bool true
+  defaults write com.apple.finder ShowPathbar -bool true
+  defaults write com.apple.finder ShowStatusBar -bool true
+  defaults write com.apple.finder FXDefaultSearchScope -string "SCcf"
+  defaults write com.apple.finder FXEnableExtensionChangeWarning -bool false
+
+  # --- Keyboard ---
+  defaults write NSGlobalDomain KeyRepeat -int 2
+  defaults write NSGlobalDomain InitialKeyRepeat -int 15
+
+  # --- Text Input ---
+  defaults write NSGlobalDomain NSAutomaticCapitalizationEnabled -bool false
+  defaults write NSGlobalDomain NSAutomaticPeriodSubstitutionEnabled -bool false
+
+  # --- Screenshot ---
+  defaults write com.apple.screencapture type -string "png"
+
+  # Apply changes
+  killall Dock 2>/dev/null || true
+  killall Finder 2>/dev/null || true
+
+  echo "✅ macOS preferences configured"
+}


### PR DESCRIPTION
## Summary
- `scripts/lib/macos.sh` を新設し、macOS システム設定を `defaults write` で自動化
- `install.sh` に組み込み、新しい Mac セットアップ時に自動実行
- CI に関数存在チェックを追加

## 設定内容
- **Dock**: 自動非表示、サイズ26、右配置、拡大有効
- **Finder**: 拡張子表示、パスバー、ステータスバー、カレントフォルダ検索
- **キーボード**: キーリピート高速化（KeyRepeat=2, InitialKeyRepeat=15）
- **入力補正**: 自動大文字・ピリオド挿入を無効化
- **スクリーンショット**: PNG形式

## Test plan
- [ ] `shellcheck scripts/lib/macos.sh` がパスすること
- [ ] CI が通ること
- [ ] 新 Mac で `install.sh` 実行後、Dock 等の設定が反映されること