### PR TITLE
fix: macOSでfc-listが使えない場合のフォント検出を修正

### DIFF
--- a/scripts/lib/brew.sh
+++ b/scripts/lib/brew.sh
@@ -63,7 +63,17 @@ install_additional_fonts() {
   echo "🎨 Checking additional font requirements..."
   
   # Check if we have adequate fonts for Powerlevel10k
-  if ! fc-list | grep -i "nerd\|powerline\|meslo\|fira" >/dev/null 2>&1; then
+  # fc-list is not available on macOS by default, so check Homebrew cask and ~/Library/Fonts
+  local has_font=false
+  if brew list --cask 2>/dev/null | grep -q "font-.*nerd-font\|font-meslo"; then
+    has_font=true
+  elif ls ~/Library/Fonts/ 2>/dev/null | grep -qi "nerd\|powerline\|meslo\|fira"; then
+    has_font=true
+  elif command -v fc-list &>/dev/null && fc-list | grep -i "nerd\|powerline\|meslo\|fira" >/dev/null 2>&1; then
+    has_font=true
+  fi
+
+  if [ "$has_font" = false ]; then
     echo "⚠️  No Nerd Fonts detected, installing Powerline fonts as fallback..."
     
     local temp_dir


### PR DESCRIPTION
## Summary

- `fc-list` はmacOSにデフォルトで存在しないため、Brewfileで`font-meslo-lg-nerd-font`をインストール済みでも誤検知してPowerlineフォントが不要にインストールされる問題を修正
- 検出の優先順位を変更:
  1. `brew list --cask` でHomebrew経由のフォントを確認
  2. `~/Library/Fonts/` を直接確認
  3. `fc-list` が存在する場合のみフォールバックとして使用

## Test plan

- [ ] `font-meslo-lg-nerd-font` をBrewfileでインストール済みの状態でinstall.shを実行し、Powerlineフォントの不要なフォールバックインストールが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)