### PR TITLE
fix: 非ログインシェルのsheldon読込バグ修正とCI shellcheck有効化・整理

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
         run: brew install shellcheck sheldon fzf mise ghq
 
       - name: Shellcheck
-        run: find scripts -name "*.sh" -exec shellcheck -x {} \;
+        run: find scripts -name '*.sh' -print0 | xargs -0 shellcheck -x
 
       - name: Verify symlink creation
         run: |

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,6 +3,7 @@
 # Dotfiles installation script for macOS
 # Refactored for simplicity and modularity
 
+# shellcheck source-path=SCRIPTDIR
 set -e  # Exit on error
 
 echo "🚀 Starting dotfiles installation..."
@@ -22,9 +23,13 @@ fi
 echo "✅ macOS detected"
 
 # Source utility libraries
+# shellcheck source=lib/brew.sh
 source "$SCRIPT_DIR/lib/brew.sh"
+# shellcheck source=lib/symlinks.sh
 source "$SCRIPT_DIR/lib/symlinks.sh"
+# shellcheck source=lib/zsh.sh
 source "$SCRIPT_DIR/lib/zsh.sh"
+# shellcheck source=lib/macos.sh
 source "$SCRIPT_DIR/lib/macos.sh"
 
 # Create necessary directories

--- a/scripts/install_win.sh
+++ b/scripts/install_win.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-ln -snfv $HOME/dotfiles/.bashrc $HOME/.bashrc
-ln -snfv $HOME/dotfiles/.bash_profile $HOME/.bash_profile
-ln -snfv $HOME/dotfiles/.profile $HOME/.profile
-

--- a/scripts/lib/brew.sh
+++ b/scripts/lib/brew.sh
@@ -17,6 +17,7 @@ install_homebrew() {
   # Add Homebrew to PATH for both Intel and Apple Silicon Macs
   if [ -f "/opt/homebrew/bin/brew" ]; then
     if ! grep -q '/opt/homebrew/bin/brew shellenv' ~/.zprofile 2>/dev/null; then
+      # shellcheck disable=SC2016  # literal line is written verbatim to ~/.zprofile by design
       echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
       echo "✅ Added Homebrew to ~/.zprofile"
     fi
@@ -24,6 +25,7 @@ install_homebrew() {
     export PATH="/opt/homebrew/bin:$PATH"
   elif [ -f "/usr/local/bin/brew" ]; then
     if ! grep -q '/usr/local/bin/brew shellenv' ~/.zprofile 2>/dev/null; then
+      # shellcheck disable=SC2016  # literal line is written verbatim to ~/.zprofile by design
       echo 'eval "$(/usr/local/bin/brew shellenv)"' >> ~/.zprofile
       echo "✅ Added Homebrew to ~/.zprofile"
     fi
@@ -67,7 +69,7 @@ install_additional_fonts() {
   local has_font=false
   if brew list --cask 2>/dev/null | grep -q "font-.*nerd-font\|font-meslo"; then
     has_font=true
-  elif ls ~/Library/Fonts/ 2>/dev/null | grep -qi "nerd\|powerline\|meslo\|fira"; then
+  elif [ -n "$(find "$HOME/Library/Fonts" -maxdepth 1 \( -iname '*nerd*' -o -iname '*powerline*' -o -iname '*meslo*' -o -iname '*fira*' \) -print -quit 2>/dev/null)" ]; then
     has_font=true
   elif command -v fc-list &>/dev/null && fc-list | grep -i "nerd\|powerline\|meslo\|fira" >/dev/null 2>&1; then
     has_font=true

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -3,6 +3,10 @@ if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]
   source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
 fi
 
+# Homebrew / PATH (must precede sheldon, mise, fzf — also runs for non-login shells)
+export PATH="/opt/homebrew/bin:$HOME/go/bin:$HOME/bin:$PATH"
+eval "$(/opt/homebrew/bin/brew shellenv)"
+
 # History
 HISTFILE=~/.zsh_history
 HISTSIZE=50000
@@ -30,12 +34,6 @@ setopt INTERACTIVE_COMMENTS
 
 # Sheldon plugins
 eval "$(sheldon source)"
-
-# PATH
-export PATH="/opt/homebrew/bin:$HOME/go/bin:$HOME/bin:$PATH"
-
-# Homebrew
-eval "$(/opt/homebrew/bin/brew shellenv)"
 
 # Antigravity
 export PATH="$HOME/.antigravity/antigravity/bin:$PATH"


### PR DESCRIPTION
## 概要

新しい Mac へ本リポジトリでセットアップする過程で見つかった、実害のあるバグ2件とレガシー整理1件を修正します。

## 変更点

### 1. fix: 非ログインシェルで sheldon が読み込めない問題 (`zsh/.zshrc`)
`eval "$(sheldon source)"` が PATH/Homebrew 設定より**前**に実行されていた。ログインシェルは `.zprofile` 経由で救われるが、**非ログインの対話シェル**（tmux サブシェル、`zsh -i`、エディタ内シェル等）では `sheldon` が PATH 上に無く `command not found` となりプロンプト・プラグインが全滅する。Homebrew/PATH 設定を p10k instant prompt 直後・`sheldon source` より前へ移動して解消。

- 再現確認: `env -i HOME=$HOME PATH=/usr/bin:/bin ... zsh -ic` で修正前は `~/.zshrc:32: command not found: sheldon`、修正後はエラー無し・`sheldon` 解決を確認。

### 2. fix: CI の shellcheck が実質ノーチェックだった (`.github/workflows/ci.yaml`)
`find scripts -name "*.sh" -exec shellcheck -x {} \;` は `find` 自体が常に終了コード0を返すため、shellcheck がエラーを出しても CI が常にグリーンになりリント工程が機能していなかった。`find -print0 | xargs -0 shellcheck -x`（pipefail）に変更しジョブが正しく落ちるよう修正。

ゲート厳格化に伴い既存スクリプトを shellcheck クリーン化:
- `install.sh`: 動的 `source` を追従させる `shellcheck source-path=SCRIPTDIR` / `source=` ディレクティブを追加（SC1091）
- `lib/brew.sh`: `~/.zprofile` へ意図的にリテラル出力する2箇所を `SC2016` disable で明示（二重引用符化すると書き込み時に展開されてしまうため抑制が正）
- `lib/brew.sh`: フォント検出の `ls ~/Library/Fonts | grep` を `find` ベースに書き換え（SC2010）

### 3. chore: 実体のない `scripts/install_win.sh` を削除
存在しない `$HOME/dotfiles/.bashrc` / `.bash_profile` / `.profile` を symlink しようとする壊れたスクリプト。README・install.sh・CI のいずれからも参照されておらず機能していないため削除。

## テスト

- [x] `find scripts -name '*.sh' -print0 | xargs -0 shellcheck -x` がローカルで CLEAN（shellcheck 0.11.0）
- [x] 非ログインシェルのバグを再現 → 修正で解消を確認
- [x] `install.sh` を実機（Apple Silicon / macOS 26.3.1）で実行し、symlink 8件・全 CLI・sheldon プラグイン・macOS defaults まで正常適用を確認
- [ ] CI（push 時に本 PR で実行）

## 補足（PRスコープ外・report のみ）

- `zsh/aliases.zsh` の `gsm='git switch master'` はリポジトリの `init.defaultBranch=main` と不整合（運用次第のため未変更）。
- `zsh/.zshrc` / `.zprofile` は `/opt/homebrew` 決め打ち（README は Intel 対応を謳うが実質 Apple Silicon 専用）。
- セットアップ時 `docker-desktop` / `karabiner-elements` / mas `SafeInCloud 2` が sudo 非対話のため失敗。install.sh が sudo 要求 cask を扱えない点は別途要検討。

🤖 Generated with [Claude Code](https://claude.com/claude-code)