### PR TITLE
feat: direnvのzshフックを追加

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -74,3 +74,8 @@ done
 # Powerlevel10k config
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [[ -f ~/.p10k.zsh ]] && source ~/.p10k.zsh
+
+# direnv
+if command -v direnv &>/dev/null; then
+  eval "$(direnv hook zsh)"
+fi


### PR DESCRIPTION
## 概要
direnv 本体は Brewfile でインストール済み・p10k にプロンプトセグメントもありますが、肝心の zsh フック（`direnv hook zsh`）が `.zshrc` に無く、`.envrc` が自動読み込みされない状態だったため追加します。

## 変更内容
- `zsh/.zshrc` 末尾に direnv フックを追加（direnv 未インストール環境では何もしないよう `command -v` でガード）

## 動作確認
- `zsh -n` で構文チェック OK
- job-draft リポジトリの `.envrc` が新規シェルで自動読み込みされることを確認